### PR TITLE
Wrong url path for auto-sklearn

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ This repository contains a curated list of awesome open source libraries that wi
 
 
 ## Feature Engineering Automation
-* [auto-sklearn](https://automl.github.io/auto-sklearn/stable/) ![](https://img.shields.io/github/stars/automl/auto-sklearn.svg?style=social) - Framework to automate algorithm and hyperparameter tuning for sklearn
+* [auto-sklearn](https://automl.github.io/auto-sklearn/) ![](https://img.shields.io/github/stars/automl/auto-sklearn.svg?style=social) - Framework to automate algorithm and hyperparameter tuning for sklearn
 * [TPOT](https://epistasislab.github.io/tpot/) ![](https://img.shields.io/github/stars/epistasislab/tpot.svg?style=social) - Automation of sklearn pipeline creation (including feature selection, pre-processor, etc)
 * [tsfresh](https://github.com/blue-yonder/tsfresh) ![](https://img.shields.io/github/stars/blue-yonder/tsfresh.svg?style=social) - Automatic extraction of relevant features from time series
 * [Featuretools](https://www.featuretools.com/) - An open source framework for automated feature engineering


### PR DESCRIPTION
Now is `/master`, not more `/stable`. Better is put at root.