### PR TITLE
Add Arize AI to the Serving and Monitoring Section

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ This repository contains a curated list of awesome open source libraries that wi
 * [ZenML](https://github.com/maiot-io/zenml) ![](https://img.shields.io/github/stars/maiot-io/zenml.svg?style=social) - ZenML is an extensible, open-source MLOps framework to create reproducible ML pipelines with a focus on automated metadata tracking, caching, and many integrations to other tools.
 
 ## Model Serving and Monitoring
+* [Arize AI](https://github.com/Arize-ai) ![](https://img.shields.io/github/stars/backprop-ai/backprop.svg?style=social) - Machine learning observability and model monitoring platform to surface and troubleshoot drift, performance regression, and data quality issues with models in production.
 * [Backprop](https://github.com/backprop-ai/backprop) ![](https://img.shields.io/github/stars/backprop-ai/backprop.svg?style=social) - Backprop makes it simple to use, finetune, and deploy state-of-the-art ML models.
 * [BentoML](https://github.com/bentoml/BentoML) ![](https://img.shields.io/github/stars/bentoml/bentoml.svg?style=social) - BentoML is an open source framework for high performance ML model serving
 * [Cortex](https://github.com/cortexlabs/cortex) ![](https://img.shields.io/github/stars/cortexlabs/cortex.svg?style=social) - Cortex is an open source platform for deploying machine learning models—trained with any framework—as production web services. No DevOps required.


### PR DESCRIPTION
We would like to add Arize AI into the Model Serving and Monitoring section. Learn more about Arize at [https://arize.com/](https://arize.com/)