### PR TITLE
remove integrated evalkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -623,7 +623,6 @@ This repository contains a curated list of awesome open source libraries that wi
 
 ## Industry Strength Evaluation
 * [AlpacaEval](https://github.com/tatsu-lab/alpaca_eval) ![](https://img.shields.io/github/stars/tatsu-lab/alpaca_eval.svg?style=social) - AlpacaEval is an automatic evaluator for instruction-following language models.
-* [BigCodeBench](https://github.com/bigcode-project/bigcodebench) ![](https://img.shields.io/github/stars/bigcode-project/bigcodebench.svg?style=social) - BigCodeBench is an easy-to-use benchmark for code generation with practical and challenging programming tasks.
 * [Code Generation LM Evaluation Harness](https://github.com/bigcode-project/bigcode-evaluation-harness) ![](https://img.shields.io/github/stars/bigcode-project/bigcode-evaluation-harness.svg?style=social) - Code Generation LM Evaluation Harness is a framework for the evaluation of code generation models.
 * [crfm-helm](https://github.com/stanford-crfm/helm) ![](https://img.shields.io/github/stars/stanford-crfm/helm.svg?style=social) - crfm-helm provides tools for the holistic evaluation of language models, including standardized datasets, a unified API for various models, diverse metrics, robustness and fairness perturbations, a prompt construction framework, and a proxy server for unified model access.
 * [DeepEval](https://github.com/confident-ai/deepeval) ![](https://img.shields.io/github/stars/confident-ai/deepeval.svg?style=social) - DeepEval is a simple-to-use, open-source evaluation framework for LLM applications.


### PR DESCRIPTION
BigCodeBench would be integrated to bigcode-evaluation-harness, and you can also run it there. As it is written in its recent update....