### PR TITLE
at least 10 tools to qualify as a new module

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ When proposing a new tool or section, please keep the following in mind:
 * Tools should not be listed in more than one section.
 * Tools should not be archived and must have been actively maintained within the last 6 months.
 * Ensure that all contributions are listed in alphabetical order within their respective sections.
-* Before adding a new section, please open an issue for discussion. A new section will only be considered if at least 5-10 new tools can be identified, demonstrating a clear need for the sub-area.
+* Before adding a new section, please open an issue for discussion. A new section will only be considered if at least 10 new tools can be identified, demonstrating a clear need for the sub-area.
 
 # Review Process
 


### PR DESCRIPTION
With the number of toolchains growing fast, there is a need to tighten the bar to qualify a new module. Some small domains, might not be impactful or mature enough to qualify as a new module (< 10 production-level tools)