### PR TITLE
Add Agentset to Industry Strength Information Retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,6 +414,7 @@ Please review our [CONTRIBUTING.md](https://github.com/EthicalML/awesome-product
 * [VideoSys](https://github.com/NUS-HPC-AI-Lab/VideoSys) ![](https://img.shields.io/github/stars/NUS-HPC-AI-Lab/VideoSys.svg?cacheSeconds=86400) - VideoSys supports many diffusion models with our various acceleration techniques, enabling these models to run faster and consume less memory.
 
 ## Industry Strength Information Retrieval
+* [Agentset](https://github.com/agentset-ai/agentset) ![](https://img.shields.io/github/stars/agentset-ai/agentset.svg?cacheSeconds=86400) - Agentset is an open-source platform to build, evaluate, and ship production-ready RAG and agentic applications with end-to-end tooling: ingestion, vector indexing, evaluation, chat playground, hosting, and developer API.
 * [AutoRAG](https://github.com/Marker-Inc-Korea/AutoRAG) ![](https://img.shields.io/github/stars/Marker-Inc-Korea/AutoRAG.svg?cacheSeconds=86400) - AutoRAG is a RAG AutoML tool for automatically finds an optimal RAG pipeline for your data.
 * [BGE](https://github.com/FlagOpen/FlagEmbedding) ![](https://img.shields.io/github/stars/FlagOpen/FlagEmbedding.svg?cacheSeconds=86400) - BGE builds one-stop retrieval toolkit for search and RAG.
 * [Cognita](https://github.com/truefoundry/cognita) ![](https://img.shields.io/github/stars/truefoundry/cognita.svg?cacheSeconds=86400) - Cognita is a RAG framework for building modular and production-ready applications.


### PR DESCRIPTION
This PR adds Agentset to the **Industry Strength Information Retrieval** section.

[Agentset](https://agentset.ai) is an open-source platform to build, evaluate, and ship production-ready RAG and agentic applications with end-to-end tooling: ingestion, vector indexing, evaluation, chat playground, hosting, and developer API.

**Checklist:**
- Tool is open source with 500+ GitHub stars
- Actively maintained within the last 12 months
- Listed in alphabetical order
- Not listed in any other section
- Link verified and working
- Description follows list style conventions