### PR TITLE
Add AgentWatch to Evaluation and Monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,7 @@ Please review our [CONTRIBUTING.md](https://github.com/EthicalML/awesome-product
 
 
 ## Evaluation and Monitoring
+* [AgentWatch](https://github.com/nicofains1/agentwatch) ![](https://img.shields.io/github/stars/nicofains1/agentwatch.svg?cacheSeconds=86400) - AgentWatch is a multi-agent observability library for cascade failure detection, fleet-wide heartbeat monitoring, and forensic replay across agent systems.
 * [AlpacaEval](https://github.com/tatsu-lab/alpaca_eval) ![](https://img.shields.io/github/stars/tatsu-lab/alpaca_eval.svg?cacheSeconds=86400) - AlpacaEval is an automatic evaluator for instruction-following language models.
 * [ANN-Benchmarks](https://github.com/erikbern/ann-benchmarks) ![](https://img.shields.io/github/stars/erikbern/ann-benchmarks.svg?cacheSeconds=86400) - ANN-Benchmarks is a benchmarking environment for approximate nearest neighbor algorithms search.
 * [ARES](https://github.com/stanford-futuredata/ARES) ![](https://img.shields.io/github/stars/stanford-futuredata/ARES.svg?cacheSeconds=86400) - ARES is a framework for automatically evaluating Retrieval-Augmented Generation (RAG) models.


### PR DESCRIPTION
Adds [AgentWatch](https://github.com/nicofains1/agentwatch) to the Evaluation and Monitoring section. AgentWatch is an open-source multi-agent observability library for detecting cascade failures across agent systems, with fleet-wide heartbeat monitoring and forensic replay. Published on npm as @nicofains1/agentwatch.