### PR TITLE
Add A3M Router to Deployment and Serving section

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,7 @@ Please review our [CONTRIBUTING.md](https://github.com/EthicalML/awesome-product
 
 
 ## Deployment and Serving
+* [A3M Router](https://github.com/Das-rebel/a3m-router) ![](https://img.shields.io/github/stars/Das-rebel/a3m-router.svg?cacheSeconds=86400) - Open-source LLM router with parallel multi-LLM execution across 47+ providers. Confidence-scored routing (not sequential fallback). 62% cost savings, 99.5% routing accuracy.
 * [Agenta](https://github.com/Agenta-AI/agenta) ![](https://img.shields.io/github/stars/Agenta-AI/agenta.svg?cacheSeconds=86400) - Agenta provides end-to-end tools for the entire LLMOps workflow: building (LLM playground, evaluation), deploying (prompt and configuration management), and  (LLM observability and tracing).
 * [AirLLM](https://github.com/lyogavin/airllm) ![](https://img.shields.io/github/stars/lyogavin/airllm.svg?cacheSeconds=86400) - AirLLM optimizes inference memory usage, allowing 70B large language models to run inference on a single 4GB GPU card without quantization, distillation and pruning.
 * [AITemplate](https://github.com/facebookincubator/AITemplate) ![](https://img.shields.io/github/stars/facebookincubator/AITemplate.svg?cacheSeconds=86400) - AITemplate (AIT) is a Python framework that transforms deep neural networks into CUDA (NVIDIA GPU) / HIP (AMD GPU) C++ code for lightning-fast inference serving.


### PR DESCRIPTION
## Add A3M Router

**Project:** [A3M Router](https://github.com/Das-rebel/a3m-router) - Open-source LLM router with parallel multi-LLM execution across 47+ providers.

**Why it fits:** Unlike LiteLLM (already listed) which does sequential fallback, A3M Router does parallel multi-LLM execution with confidence-scored voting. This is a fundamentally different approach to LLM routing — query multiple providers simultaneously and merge results by confidence score. 62% cost savings, 99.5% routing accuracy. 19.5 KB CLI, zero ML dependencies.

**npm:** `npm install -g adaptive-memory-multi-model-router`
**Benchmark:** docs/BENCHMARK.md

---

> 🏆 **RouterArena #1** — 🏆 RouterArena #1: A3M scored 76.43 on the official LLM router benchmark — beating Microsoft Azure (71.87), OpenAI GPT-5 (64.32), and RouteLLM (48.07). Results: https://github.com/RouteWorks/RouterArena/pull/113
