### PR TITLE
Add Awesome AI Gateway to Other Awesome Lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -675,6 +675,7 @@ Please review our [CONTRIBUTING.md](https://github.com/EthicalML/awesome-product
 
 # Other Awesome Lists
 
+* [Awesome AI Gateway](https://github.com/cuihuan/awesome-ai-gateway) - Curated, bilingual (EN/zh-CN) list of AI gateways and LLM proxies (LiteLLM, OpenRouter, Portkey, Kong, Higress, new-api) compared by cost, compliance, self-hosting and routing, with a decision tree, reproducible cost benchmarks and a selection scorecard.
 * [Awesome AI Regulation](https://github.com/EthicalML/awesome-artificial-intelligence-regulation) - Covers governance, compliance, and regulatory frameworks essential for responsible ML system deployment across different jurisdictions.
 * [Awesome Production GenAI](https://github.com/EthicalML/awesome-production-genai) - Focuses specifically on generative AI deployment, including LLM operations, prompt engineering, and GenAI-specific monitoring and safety tools.
 * [Awesome RAG Production](https://github.com/Yigtwxx/Awesome-RAG-Production) - Curated list of production-grade tools and best practices for building scalable RAG systems.


### PR DESCRIPTION
### What

Adds **[Awesome AI Gateway](https://github.com/cuihuan/awesome-ai-gateway)** to the **Other Awesome Lists** section.

### Why it fits

This is a curated *awesome list* (not a single tool), so it belongs alongside the existing entries in **Other Awesome Lists** (Awesome AI Regulation, Awesome Production GenAI, Awesome RAG Production) rather than in a tool category. It complements *Awesome Production GenAI* by going deep on one production concern this list doesn't otherwise cover end-to-end: the **AI gateway / LLM-proxy** layer.

It's a bilingual (EN + zh-CN) comparison of AI gateways and LLM proxies — LiteLLM, OpenRouter, Portkey, Kong AI Gateway, Higress, new-api, Bifrost, Envoy AI Gateway and others — organized by what teams actually need (cost, compliance, self-hosting, routing, China ecosystem, MCP/agent gateways), with a decision tree, a reproducible cost benchmark, and a selection scorecard. It carries the awesome.re badge and its data is refreshed daily via CI.

I placed it first to keep the section alphabetical ("Awesome AI **G**ateway" before "Awesome AI **R**egulation"). Single-line change, trailing-period format matched to the section. Thanks for maintaining this list!