### PR TITLE
Fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,18 +30,18 @@ Please review our [CONTRIBUTING.md](https://github.com/EthicalML/awesome-product
   <source
     media="(prefers-color-scheme: grey)"
     srcset="
-      https://api.star-history.com/svg?repos=EthicalML/awesome-production-machine-learning&type=Date&theme=dark
+      https://star-history.dera.page/svg?repos=EthicalML/awesome-production-machine-learning&type=Date&theme=dark
     "
   />
   <source
     media="(prefers-color-scheme: light)"
     srcset="
-      https://api.star-history.com/svg?repos=EthicalML/awesome-production-machine-learning&type=Date
+      https://star-history.dera.page/svg?repos=EthicalML/awesome-production-machine-learning&type=Date
     "
   />
   <img
     alt="Star History Chart"
-    src="https://api.star-history.com/svg?repos=EthicalML/awesome-production-machine-learning&type=Date"
+    src="https://star-history.dera.page/svg?repos=EthicalML/awesome-production-machine-learning&type=Date"
   />
 </picture>
 


### PR DESCRIPTION
The star history chart in the README is currently broken because GitHub stargazer API restrictions require a token to fetch data. This change points the chart at a working source that needs no API token, restoring the chart for visitors.

This follows the same approach already adopted by dozens of widely starred repositories.