### PR TITLE
Add a monthly list-currency check

### DIFF
--- a/.github/scripts/check_currency.py
+++ b/.github/scripts/check_currency.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Check every GitHub link in README.md against the CONTRIBUTING.md criteria.
+
+Reports entries whose upstream repository is archived, has had no push in over
+12 months, or has moved to a new owner/name. Standard library only; uses the
+GITHUB_TOKEN already available to Actions.
+
+Writes a markdown report to the path given by --out (default: currency-report.md)
+and prints the number of findings to stdout. Always exits 0 unless the check
+itself fails — a listed project going archived is news for the maintainers, not
+a broken build.
+"""
+
+import argparse
+import datetime
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+
+GRAPHQL = "https://api.github.com/graphql"
+BATCH = 50
+STALE_MONTHS = 12
+
+ENTRY = re.compile(r"^\*\s*\[[^\]]+\]\((https://github\.com/([\w.-]+)/([\w.-]+))/?\)", re.M)
+
+
+def query(token, repos):
+    """Return {owner/name: metadata or None} for one batch."""
+    parts = []
+    for i, repo in enumerate(repos):
+        owner, name = repo.split("/", 1)
+        parts.append(
+            f'r{i}: repository(owner: "{owner}", name: "{name}") '
+            "{ nameWithOwner isArchived pushedAt }"
+        )
+    body = json.dumps({"query": "{" + " ".join(parts) + "}"}).encode()
+    req = urllib.request.Request(
+        GRAPHQL,
+        data=body,
+        headers={
+            "Authorization": f"bearer {token}",
+            "Content-Type": "application/json",
+            "User-Agent": "awesome-production-machine-learning-currency-check",
+        },
+    )
+    with urllib.request.urlopen(req, timeout=60) as resp:
+        payload = json.load(resp)
+    data = payload.get("data") or {}
+    return {repo: data.get(f"r{i}") for i, repo in enumerate(repos)}
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--readme", default="README.md")
+    ap.add_argument("--out", default="currency-report.md")
+    args = ap.parse_args()
+
+    token = os.environ.get("GITHUB_TOKEN")
+    if not token:
+        sys.exit("GITHUB_TOKEN is not set")
+
+    text = open(args.readme, encoding="utf-8").read()
+    repos = sorted({f"{m.group(2)}/{m.group(3)}" for m in ENTRY.finditer(text)})
+
+    status = {}
+    for i in range(0, len(repos), BATCH):
+        batch = repos[i : i + BATCH]
+        try:
+            status.update(query(token, batch))
+        except urllib.error.URLError as exc:
+            sys.exit(f"GitHub API request failed: {exc}")
+
+    cutoff = (
+        datetime.date.today() - datetime.timedelta(days=365 * STALE_MONTHS // 12)
+    ).isoformat()
+
+    archived, stale, moved, missing = [], [], [], []
+    for repo, meta in sorted(status.items()):
+        if meta is None:
+            missing.append(repo)
+            continue
+        pushed = meta["pushedAt"][:10]
+        if meta["isArchived"]:
+            archived.append((repo, pushed))
+        elif pushed < cutoff:
+            stale.append((repo, pushed))
+        if meta["nameWithOwner"].lower() != repo.lower():
+            moved.append((repo, meta["nameWithOwner"]))
+
+    lines = [
+        f"Checked {len(repos)} GitHub entries in `{args.readme}` on "
+        f"{datetime.date.today().isoformat()}.",
+        "",
+        "Criteria from CONTRIBUTING.md: *tools should not be archived and must have "
+        "been actively maintained within the last 12 months.*",
+        "",
+    ]
+
+    def section(title, rows, render):
+        lines.append(f"### {title} ({len(rows)})")
+        lines.append("")
+        if rows:
+            lines.extend(render(r) for r in rows)
+        else:
+            lines.append("_None._")
+        lines.append("")
+
+    section(
+        "Archived upstream",
+        archived,
+        lambda r: f"- `{r[0]}` — last push {r[1]}",
+    )
+    section(
+        f"No push in over {STALE_MONTHS} months",
+        stale,
+        lambda r: f"- `{r[0]}` — last push {r[1]}",
+    )
+    section("Moved or renamed", moved, lambda r: f"- `{r[0]}` → `{r[1]}`")
+    section("Unreachable (deleted or private)", missing, lambda r: f"- `{r}`")
+
+    open(args.out, "w", encoding="utf-8").write("\n".join(lines))
+    print(len(archived) + len(stale) + len(missing))
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/currency-check.yml
+++ b/.github/workflows/currency-check.yml
@@ -1,0 +1,45 @@
+name: List Currency Check
+
+# Runs monthly, just after the release PDF build on the 1st, and reports any
+# listed project that no longer meets the CONTRIBUTING.md criteria. Opens an
+# issue with the findings rather than failing a build — a listed project being
+# archived upstream is news to act on, not a broken repository.
+on:
+  workflow_dispatch: {}
+  schedule:
+    # the day after the monthly release
+    - cron: "0 0 2 * *"
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  check:
+    name: check-list-currency
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check every GitHub entry
+        id: check
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          findings=$(python3 .github/scripts/check_currency.py \
+            --readme README.md --out currency-report.md)
+          echo "findings=$findings" >> "$GITHUB_OUTPUT"
+
+      - name: Open an issue if anything needs attention
+        if: steps.check.outputs.findings != '0'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh issue create \
+            --title "List currency check: ${{ steps.check.outputs.findings }} entries need attention ($(date +'%Y-%m'))" \
+            --body-file currency-report.md
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: currency-report
+          path: currency-report.md


### PR DESCRIPTION
## Automate the list-currency check

In #383 you wrote:

> I also wonder if we could think of a way to automatically validate this (ie do a
> quick automated check once we merge the release PR)

This is that check.

### What it does

A monthly workflow that reads every GitHub link in `README.md` and reports any entry
that no longer meets the CONTRIBUTING.md criterion — *"Tools should not be archived
and must have been actively maintained within the last 12 months"*.

- **Runs on the 2nd of each month**, the day after the existing `release.yml` PDF
  build, matching the "once we merge the release PR" cadence from #383.
  Also `workflow_dispatch` for a manual run.
- **Opens an issue with the findings. It never fails the build.** A listed project
  going archived upstream is news to act on, not a broken repository — a
  hand-curated list should not go red because someone else archived their repo last
  week. If there is nothing to report, no issue is opened.
- The report is also uploaded as an artifact on every run.

### Why a link checker does not catch this

None of these URLs 404. Every one resolves with HTTP 200 — an archived or abandoned
repository is served exactly like a healthy one. The only way to see it is to ask the
GitHub API for `isArchived` and `pushedAt`, which is what this does.

### Implementation

- `.github/scripts/check_currency.py` — **standard library only**, no new
  dependencies. Batched GraphQL, 50 repositories per request, so the whole list is
  about a dozen API calls against the `GITHUB_TOKEN` that Actions already provides.
- `.github/workflows/currency-check.yml` — `contents: read` + `issues: write`,
  nothing wider.

The report separates four categories:

- **Archived upstream** and **no push in over 12 months** — direct criterion
  violations.
- **Moved or renamed** — reported for information only. These are deliberately
  **excluded from the count that triggers an issue**, since GitHub redirects them and
  nothing breaks; they just leave the URL and the shields.io badge path stale.
- **Unreachable** — deleted or gone private.

### Verification

Run against the list as it stood before #811, it reported **545 entries, 76 findings,
25 archived** — reproducing that audit exactly, which is where #811's 25 removals came
from. Re-running it now that #811 has merged is the natural first live test.

A sample of the generated report is in the workflow artifact; the format is plain
markdown, one bullet per entry with its last-push date.

### Note

Happy to change the schedule, the report format, or have it post to an existing issue
instead of opening a new one — whatever fits how you actually want to consume it.
